### PR TITLE
Fixed: cross-device /tmp does not work

### DIFF
--- a/versionner/commands/files_management.py
+++ b/versionner/commands/files_management.py
@@ -71,7 +71,7 @@ def update_project_files(cfg, proj_version):
             fh_out.close()
 
             shutil.copystat(project_file.filename, fh_out.name)
-            pathlib.Path(fh_out.name).rename(project_file.filename)
+            shutil.move(fh_out.name, project_file.filename)
 
     return counters
 

--- a/versionner/version.py
+++ b/versionner/version.py
@@ -223,15 +223,7 @@ class VersionFile():
         if self._path.exists():
             shutil.copystat(str(self._path), fh.name)
 
-        try:
-            shutil.move(fh.name, self._path)
-        except OSError as exc:
-            # handling situation with tmp file on another device
-            if exc.errno == 18 and 'Invalid cross-device link' in exc.strerror:
-                with self._path.open(mode='w') as fh:
-                    fh.write(str(version))
-            else:
-                raise
+        shutil.move(fh.name, self._path)
 
     def __str__(self):
         return str(self._path)

--- a/versionner/version.py
+++ b/versionner/version.py
@@ -224,7 +224,7 @@ class VersionFile():
             shutil.copystat(str(self._path), fh.name)
 
         try:
-            pathlib.Path(fh.name).rename(self._path)
+            shutil.move(fh.name, self._path)
         except OSError as exc:
             # handling situation with tmp file on another device
             if exc.errno == 18 and 'Invalid cross-device link' in exc.strerror:


### PR DESCRIPTION
Hi,

I really like what your project does. However, the overwriting of files did not work me. The problem was that the os.rename could not move files across file system boundaries (and I have /tmp on a different partition than /home).

The solution (according to the stackoverflow answer https://stackoverflow.com/a/43967659 - dangerous, I know ;-) ) is to use `shutil.move`. 

What do you think? Would that work for you?

Thanks,
Jan